### PR TITLE
Fix dynaconf environment variables setup in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ $ docker build -t takeoff .
 $ docker run -it -p 8000:80 --gpus all -v $HOME/.iris_cache/:/code/models/  --entrypoint /bin/bash takeoff
 
 # set the models and device
-export MODEL_NAME=t5-small
-export DEVICE=cuda # or cpu
+export TAKEOFF_MODEL_NAME=t5-small
+export TAKEOFF_DEVICE=cuda # or cpu
 
 # This will run the CT2 convert and then spin up the fastAPI server
 $ sh run.sh 


### PR DESCRIPTION
This commit addresses an issue in the README documentation regarding the setup of environment variables for dynaconf configuration. The previous instructions were incorrect and could lead to confusion for users. You have the `envvar_prefix` set as TAKEOFF in the config.py file.