### PR TITLE
Fixed generation max length bugs on chat and playground, Added cancel…

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -257,12 +257,19 @@ async def generate_stream_helper(
 
     step_results = generator.generate_tokens(prompt_tokens, **params)
 
+    unwanted_patterns = [tokenizer.eos_token, "User", "Assistant"]
     for step_result in step_results:
-        # this is for llama tokenizer to decode with space
+        # Decode the token content
         if step_result.token.startswith("▁"):
-            yield " " + tokenizer.decode(step_result.token_id)  # pre pend a whitie space
+            token_content = " " + tokenizer.decode(step_result.token_id)
         else:
-            yield tokenizer.decode(step_result.token_id)
+            token_content = tokenizer.decode(step_result.token_id)
+        if token_content in unwanted_patterns:
+            break
+        else:
+            for char in token_content:
+                yield char
+                await asyncio.sleep(0)
 
 
 @app.post("/generate_stream")

--- a/app/static/chat/index.html
+++ b/app/static/chat/index.html
@@ -10,6 +10,7 @@
           "The following is a discussion between a human and a knowledgeable and empathetic assistant. You are the Assistant. Please give a single response, in your role as the Assistant. \n\n",
         user_name: "User",
         bot_name: "Assistant",
+        host: "http://localhost:8000",
         generation_parameters: {
           generate_max_length: 300,
           no_repeat_ngram_size: 3,
@@ -274,8 +275,10 @@
           >
           <input
             id="sampling-temperature"
-            type="text"
+            type="number"
+            step=0.01
             class="block px-4 py-2 text-sm w-full config-input"
+            value=0.7
           />
           <label
             class="block px-4 py-2 text-sm text-gray-700"
@@ -284,8 +287,12 @@
           >
           <input
             id="sampling-topp"
-            type="text"
+            type="number"
             class="block px-4 py-2 text-sm w-full config-input"
+            step=0.01
+            min=0
+            max=1
+            value=0.1
           />
           <label
             class="block px-4 py-2 text-sm text-gray-700"
@@ -294,8 +301,10 @@
           >
           <input
             id="sampling-topk"
-            type="text"
+            type="number"
             class="block px-4 py-2 text-sm w-full config-input"
+            value=50
+            min=0
           />
           <label
             class="block px-4 py-2 text-sm text-gray-700"
@@ -304,8 +313,10 @@
           >
           <input
             id="repetition-penalty"
-            type="text"
+            type="number"
             class="block px-4 py-2 text-sm w-full config-input"
+            step=0.01
+            value=1.2
           />
           <label
             class="block px-4 py-2 text-sm text-gray-700"
@@ -314,8 +325,10 @@
           >
           <input
             id="generate-max-length"
-            type="text"
+            type="number"
             class="block px-4 py-2 text-sm w-full config-input"
+            value=300
+            min=1
           />
           <label
             class="block px-4 py-2 text-sm text-gray-700"
@@ -324,8 +337,10 @@
           >
           <input
             id="no-repeat-ngram-size"
-            type="text"
+            type="number"
             class="block px-4 py-2 text-sm w-full config-input"
+            value=3
+            min=0
           />
         </div>
         <div class="py-1">
@@ -345,7 +360,6 @@
       <!-- Chat messages will appear here -->
     </div>
     <form
-      onsubmit="event.preventDefault(); sendData()"
       class="form-style shadow-md rounded px-8 pt-6 pb-8 mb-4 flex"
     >
       <input
@@ -355,14 +369,19 @@
         placeholder="Enter message"
       />
       <button
-        type="submit"
+        id="action-button"
+        type="button"
         class="button-style select-none font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline ml-2 flex justify-center items-center"
+        disabled
+        onclick="handleButtonClick()"
       >
         <i class="fas fa-paper-plane"></i>
       </button>
     </form>
     <script>
       window.onload = onLoad;
+      let ongoingRequest = false;
+      let controller = new AbortController();
 
       document
         .getElementById("settings-btn")
@@ -383,17 +402,17 @@
             system_prompt: document.getElementById("system-prompt").value,
             // get other form inputs similarly
             generation_parameters: {
-              sampling_temperature: document.getElementById(
+              sampling_temperature: Number(document.getElementById(
                 "sampling-temperature",
-              ).value,
-              sampling_topp: document.getElementById("sampling-topp").value,
-              sampling_topk: document.getElementById("sampling-topk").value,
+              ).value),
+              sampling_topp: Number(document.getElementById("sampling-topp").value),
+              sampling_topk: Number(document.getElementById("sampling-topk").value),
               repetition_penalty:
-                document.getElementById("repetition-penalty").value,
-              max_length: document.getElementById("generate-max-length").value,
-              no_repeat_ngram_size: document.getElementById(
+                Number(document.getElementById("repetition-penalty").value),
+              generate_max_length: Number(document.getElementById("generate-max-length").value),
+              no_repeat_ngram_size: Number(document.getElementById(
                 "no-repeat-ngram-size",
-              ).value,
+              ).value),
             },
           };
           // run through the values in configuration. If any of them is the empty string, delete the corresponding key.
@@ -407,7 +426,7 @@
           for (const [key, value] of Object.entries(
             configuration.generation_parameters,
           )) {
-            if (value === "") {
+            if (value === "" || value === 0) {
               delete configuration.generation_parameters[key];
             }
           }
@@ -459,6 +478,69 @@
         setInitialIconStyle();
       }
 
+      function disableTextBox() {
+        messageInput.disabled = true;
+        messageInput.placeholder = "Streaming Response...";
+      }
+
+      function enableTextBox() {
+        messageInput.disabled = false;
+        messageInput.placeholder = "Enter message"
+      }
+
+      function validateEmptyInput() {
+        const buttonIcon = document.querySelector('#action-button');
+        if (messageInput.value === "") {
+          buttonIcon.disabled = true;
+        } else {
+          buttonIcon.disabled = false;
+        }
+      }
+
+      function changeToCancelIcon() {
+        const buttonIcon = document.querySelector('#action-button i');
+        buttonIcon.classList.remove('fa-paper-plane');
+        buttonIcon.classList.add('fa-xmark');
+      }
+
+      function changeToSendIcon() {
+        const buttonIcon = document.querySelector('#action-button i');
+        buttonIcon.classList.remove('fa-xmark');
+        buttonIcon.classList.add('fa-paper-plane');
+      }
+
+      function handleButtonClick() {
+        if (!ongoingRequest) {
+          sendData();
+        } else {
+          cancelRequest();
+        }
+      }
+
+      function cancelRequest() {
+        if (ongoingRequest && controller) {
+          controller.abort();
+        }
+      }
+
+      function submitOnEnter(event) {
+        if (event.which === 13) {
+          if (messageInput.value !== "") {
+            if (!event.repeat) {
+              handleButtonClick();
+            }
+          }
+          event.preventDefault(); // Prevents the addition of a new line in the text field
+        }
+      }
+
+      document
+        .getElementById("message-input")
+        .addEventListener("keydown", submitOnEnter);
+      document
+        .getElementById("message-input")
+        .addEventListener("input", validateEmptyInput);
+
       const chatbox = document.getElementById("chatbox");
       const messageInput = document.getElementById("message-input");
       function preprocessChat(text) {
@@ -469,44 +551,68 @@
       }
 
       async function sendData() {
+        if (ongoingRequest) {
+          console.error("Request is already ongoing.");
+          return;
+        }
+        disableTextBox();
+        changeToCancelIcon();
+        ongoingRequest = true;
+        controller = new AbortController();
+
         config = getConfiguration();
         const text = messageInput.value;
+        const buttonIcon = document.querySelector('#action-button');
         messageInput.value = "";
         addMessage(getConfiguration().user_name, text, "message user");
 
         const url = "/generate_stream";
-        console.log(url);
         body = JSON.stringify({
           text: getChatboxData() + "\nAssistant: ",
           ...config.generation_parameters,
         });
         console.log("API called with \n", getChatboxData());
-        const response = await fetch(url, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: body,
-        });
-
-        let messageElem = addMessage(
-          getConfiguration().bot_name,
-          "",
-          "message TitanBot",
-          false,
-        );
-
-        const reader = response.body
-          .pipeThrough(new TextDecoderStream())
-          .getReader();
-        while (true) {
-          const { value, done } = await reader.read();
-          if (done) break;
-
-          console.log(displayMessage(value));
-          messageElem.innerHTML = preprocessChat(
-            messageElem.innerHTML + displayMessage(value),
+        try {
+          const response = await fetch(url, {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: body,
+            signal: controller.signal,
+          });
+  
+          let messageElem = addMessage(
+            getConfiguration().bot_name,
+            "",
+            "message TitanBot",
+            false,
           );
+  
+          const reader = response.body
+            .pipeThrough(new TextDecoderStream())
+            .getReader();
+          while (true) {
+            const { value, done } = await reader.read();
+            if (done) break;
+            messageElem.innerHTML = preprocessChat(
+              messageElem.innerHTML + displayMessage(value),
+            );
+          }
+          ongoingRequest = false;
+          enableTextBox();
+          changeToSendIcon();
+          buttonIcon.disabled = true;
+        } catch (err) {
+          if (err.name === 'AbortError') {
+            console.log('Fetch aborted');
+          } else {
+            console.error('Fetch error:', err);
+          }
+          ongoingRequest = false;
+          enableTextBox();
+          changeToSendIcon();
+          buttonIcon.disabled = true;
         }
       }
 

--- a/app/static/playground/index.html
+++ b/app/static/playground/index.html
@@ -95,7 +95,7 @@
         color: var(--text-color);
         background-color: var(--input-color);
         width: 100%;
-        height: 1000px;
+        height: calc(100vh - 250px);
       }
 
       /* input boxes should always be black on white background */
@@ -173,6 +173,7 @@
         left: 0;
         right: 0;
         bottom: 0;
+        height: 34px;
         background-color: var(--button-color);
         transition: background-color 0.4s;
         border-radius: 34px;
@@ -282,8 +283,10 @@
           >
           <input
             id="sampling-temperature"
-            type="text"
+            type="number"
+            step="0.01"
             class="block px-4 py-2 text-sm w-full config-input"
+            value="0.9"
           />
           <label
             class="block px-4 py-2 text-sm text-gray-700"
@@ -292,8 +295,12 @@
           >
           <input
             id="sampling-topp"
-            type="text"
+            type="number"
+            step="0.01"
+            min="0"
+            max="1"
             class="block px-4 py-2 text-sm w-full config-input"
+            value="0.9"
           />
           <label
             class="block px-4 py-2 text-sm text-gray-700"
@@ -302,8 +309,10 @@
           >
           <input
             id="sampling-topk"
-            type="text"
+            type="number"
             class="block px-4 py-2 text-sm w-full config-input"
+            value="10"
+            min="0"
           />
           <label
             class="block px-4 py-2 text-sm text-gray-700"
@@ -312,7 +321,9 @@
           >
           <input
             id="repetition-penalty"
-            type="text"
+            type="number"
+            step="0.01"
+            value="1.2"
             class="block px-4 py-2 text-sm w-full config-input"
           />
           <label
@@ -322,8 +333,10 @@
           >
           <input
             id="generate-max-length"
-            type="text"
+            type="number"
             class="block px-4 py-2 text-sm w-full config-input"
+            value="300"
+            min="1"
           />
           <label
             class="block px-4 py-2 text-sm text-gray-700"
@@ -332,8 +345,10 @@
           >
           <input
             id="no-repeat-ngram-size"
-            type="text"
+            type="number"
             class="block px-4 py-2 text-sm w-full config-input"
+            value="3"
+            min="0"
           />
         </div>
         <div class="py-1">
@@ -351,7 +366,6 @@
     <h1 class="text-4xl text-center my-5">TitanPlayground</h1>
 
     <form
-      onsubmit="event.preventDefault(); sendData()"
       class="form-style shadow-md rounded px-8 pt-6 pb-8 mb-4 flex flex-col"
     >
       <textarea
@@ -360,19 +374,64 @@
         placeholder="Start typing here"
       ></textarea>
       <button
-        type="submit"
+        id="action-button"
+        type="button"
         class="button-style select-none font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline ml-2 items-start"
+        onclick="handleButtonClick()"
       >
         Complete <i class="fas fa-paper-plane"></i>
       </button>
     </form>
 
     <script>
+      let ongoingRequest = false;
+      let controller = new AbortController();
+      function disableTextArea() {
+        const messageInput = document.getElementById("textarea");
+        messageInput.disabled = true;
+      }
+
+      function enableTextArea() {
+        const messageInput = document.getElementById("textarea");
+        messageInput.disabled = false;
+      }
+
+      function handleButtonClick() {
+        if (!ongoingRequest) {
+          sendData();
+        } else {
+          cancelRequest();
+        }
+      }
+
+      function cancelRequest() {
+        if (ongoingRequest && controller) {
+          controller.abort();
+        }
+      }
+
+      function changeToCancelIcon() {
+        const button = document.getElementById("action-button");
+        const icon = button.querySelector("i");
+        icon.classList.remove("fa-paper-plane");
+        icon.classList.add("fa-xmark");
+        button.textContent = "Cancel ";
+        button.appendChild(icon);
+      }
+
+      function changeToSendIcon() {
+        const button = document.getElementById("action-button");
+        const icon = button.querySelector("i");
+        icon.classList.remove("fa-xmark");
+        icon.classList.add("fa-paper-plane");
+        button.textContent = "Complete ";
+        button.appendChild(icon);
+      }
+
       function submitOnEnter(event) {
         if (event.which === 13 && !event.shiftKey) {
           if (!event.repeat) {
-            const newEvent = new Event("submit", { cancelable: true });
-            event.target.form.dispatchEvent(newEvent);
+            handleButtonClick();
           }
 
           event.preventDefault(); // Prevents the addition of a new line in the text field
@@ -403,17 +462,24 @@
             system_prompt: document.getElementById("system-prompt").value,
             // get other form inputs similarly
             generation_parameters: {
-              sampling_temperature: document.getElementById(
-                "sampling-temperature",
-              ).value,
-              sampling_topp: document.getElementById("sampling-topp").value,
-              sampling_topk: document.getElementById("sampling-topk").value,
-              repetition_penalty:
+              sampling_temperature: Number(
+                document.getElementById("sampling-temperature").value,
+              ),
+              sampling_topp: Number(
+                document.getElementById("sampling-topp").value,
+              ),
+              sampling_topk: Number(
+                document.getElementById("sampling-topk").value,
+              ),
+              repetition_penalty: Number(
                 document.getElementById("repetition-penalty").value,
-              max_length: document.getElementById("generate-max-length").value,
-              no_repeat_ngram_size: document.getElementById(
-                "no-repeat-ngram-size",
-              ).value,
+              ),
+              generate_max_length: Number(
+                document.getElementById("generate-max-length").value,
+              ),
+              no_repeat_ngram_size: Number(
+                document.getElementById("no-repeat-ngram-size").value,
+              ),
             },
           };
           // run through the values in configuration. If any of them is the empty string, delete the corresponding key.
@@ -427,7 +493,7 @@
           for (const [key, value] of Object.entries(
             configuration.generation_parameters,
           )) {
-            if (value === "") {
+            if (value === "" || value === 0) {
               delete configuration.generation_parameters[key];
             }
           }
@@ -456,7 +522,6 @@
           config.generation_parameters.generate_max_length;
         document.getElementById("no-repeat-ngram-size").placeholder =
           config.generation_parameters.no_repeat_ngram_size;
-
         setInitialIconStyle();
       }
 
@@ -486,6 +551,15 @@
       }
 
       async function sendData() {
+        if (ongoingRequest) {
+          console.error("Request is already ongoing.");
+          return;
+        }
+        disableTextArea();
+        changeToCancelIcon();
+        ongoingRequest = true;
+        controller = new AbortController();
+
         config = getConfiguration();
         const textarea = document.getElementById("textarea");
         const text = textarea.value;
@@ -496,35 +570,46 @@
           ...config.generation_parameters,
         });
         console.log("API called with \n", body);
-        const response = await fetch(url, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: body,
-        });
+        try {
+          const response = await fetch(url, {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: body,
+            signal: controller.signal,
+          });
 
-        const reader = response.body
-          .pipeThrough(new TextDecoderStream())
-          .getReader();
-        while (true) {
-          const { value, done } = await reader.read();
-          if (done) break;
+          const reader = response.body
+            .pipeThrough(new TextDecoderStream())
+            .getReader();
+          while (true) {
+            const { value, done } = await reader.read();
+            if (done) break;
+            textarea.value += stripEndTokens(value);
+          }
 
-          textarea.value += stripEndTokens(displayMessage(value));
+          // Move the cursor to the end of the textarea
+          textarea.focus();
+          textarea.setSelectionRange(
+            textarea.value.length,
+            textarea.value.length,
+          );
+          ongoingRequest = false;
+          enableTextArea();
+          changeToSendIcon();
+        } catch (err) {
+          if (err.name === "AbortError") {
+            console.log("Fetch aborted");
+          } else {
+            console.error("Fetch error:", err);
+          }
+          ongoingRequest = false;
+          enableTextArea();
+          changeToSendIcon();
         }
-
-        // Move the cursor to the end of the textarea
-        textarea.focus();
-        textarea.setSelectionRange(
-          textarea.value.length,
-          textarea.value.length,
-        );
       }
 
-      function displayMessage(text) {
-        return text;
-      }
     </script>
   </body>
 </html>


### PR DESCRIPTION
# Description
This PR fixes the following bugs:
- generate_max_length field does not work in the chat and playground UI
- sending requests with empty payload is allowed

In addition, a cancel feature is added to both the chat and the playground, allow users to stop generation when needed. On the backend, end of text tokens are also removed from outputs to allow for cleaner display of generated text

Fixes #3 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Tested with the following models:
- meta-llama/Llama-2-7b-chat-hf
- tiiuae/falcon-7b-instruct

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings